### PR TITLE
Fix grammar in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
+-   Nothing (yet)!
+
 ## [3.0.0-reactpy] - 2023-03-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <!--badge-end-->
 <!--intro-start-->
 
-[ReactPy](https://reactpy.dev/) is a library for building user interfaces in Python without Javascript. ReactPy interfaces are made from components which look and behave similar to those found in [ReactJS](https://reactjs.org/). Designed with simplicity in mind, ReactPy can be used by those without web development experience while also being powerful enough to grow with your ambitions.
+[ReactPy](https://reactpy.dev/) is a library for building user interfaces in Python without Javascript. ReactPy interfaces are made from components that look and behave similar to those found in [ReactJS](https://reactjs.org/). Designed with simplicity in mind, ReactPy can be used by those without web development experience while also being powerful enough to grow with your ambitions.
 
 <table align="center">
     <thead>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <!--badge-end-->
 <!--intro-start-->
 
-[ReactPy](https://reactpy.dev/) is a library for building user interfaces in Python without Javascript. ReactPy interfaces are made from components which look and behave similarly to those found in [ReactJS](https://reactjs.org/). Designed with simplicity in mind, ReactPy can be used by those without web development experience while also being powerful enough to grow with your ambitions.
+[ReactPy](https://reactpy.dev/) is a library for building user interfaces in Python without Javascript. ReactPy interfaces are made from components which look and behave similar to those found in [ReactJS](https://reactjs.org/). Designed with simplicity in mind, ReactPy can be used by those without web development experience while also being powerful enough to grow with your ambitions.
 
 <table align="center">
     <thead>


### PR DESCRIPTION
## Description

Change `similarly` to `similar` to be gramatically correct.

## Checklist:

Please update this checklist as you complete each item:

-   [x] Tests have been included for all bug fixes or added functionality.
-   [x] The changelog has been updated with any significant changes, if necessary.
-   [x] GitHub Issues which may be closed by this PR have been linked.
