### PR TITLE
Remove `db_cleanup` from startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Using the following categories, list your changes in this order:
 
 ### Removed
 
--   `django-reactpy` database entries are no longer cleaned during Django application startup. Instead, it will occur on webpage loads, only when database after `REACTPY_RECONNECT_MAX` seconds has elapsed since the last cleaning.
+-   `django-reactpy` database entries are no longer cleaned during Django application startup. Instead, it will occur on webpage loads if `REACTPY_RECONNECT_MAX` seconds has elapsed since the last cleaning.
 
 ## [3.0.0-reactpy] - 2023-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
+### Removed
+
+-   `django-reactpy` database entries are no longer cleaned during Django application startup. Instead, it will occur on webpage loads, only when database after `REACTPY_RECONNECT_MAX` seconds has elapsed since the last cleaning.
+
 ## [3.0.0-reactpy] - 2023-03-30
 
 ### Changed

--- a/src/reactpy_django/apps.py
+++ b/src/reactpy_django/apps.py
@@ -1,12 +1,6 @@
-import logging
-
 from django.apps import AppConfig
-from django.db.utils import DatabaseError
 
-from reactpy_django.utils import ComponentPreloader, db_cleanup
-
-
-_logger = logging.getLogger(__name__)
+from reactpy_django.utils import ComponentPreloader
 
 
 class ReactPyConfig(AppConfig):
@@ -15,14 +9,3 @@ class ReactPyConfig(AppConfig):
     def ready(self):
         # Populate the ReactPy component registry when Django is ready
         ComponentPreloader().run()
-
-        # Delete expired database entries
-        # Suppress exceptions to avoid issues with `manage.py` commands such as
-        # `test`, `migrate`, `makemigrations`, or any custom user created commands
-        # where the database may not be ready.
-        try:
-            db_cleanup(immediate=True)
-        except DatabaseError:
-            _logger.debug(
-                "Could not access ReactPy database at startup. Skipping cleanup..."
-            )

--- a/tests/test_app/asgi.py
+++ b/tests/test_app/asgi.py
@@ -11,8 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-from reactpy_django import REACTPY_WEBSOCKET_PATH
-
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_app.settings")
 
@@ -22,6 +20,8 @@ http_asgi_app = get_asgi_application()
 from channels.auth import AuthMiddlewareStack  # noqa: E402
 from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
 from channels.sessions import SessionMiddlewareStack  # noqa: E402
+
+from reactpy_django import REACTPY_WEBSOCKET_PATH  # noqa: E402
 
 
 application = ProtocolTypeRouter(


### PR DESCRIPTION
## Description

Removes `db_cleanup` from startup, as it can cause issues with how the `uvicorn` CLI runs. Technically it wasn't needed to run on startup in the first place, as the cleanup will run on first websocket connect anyways.

I haven't detected this issue before since Conreq uses uvicorn's python interface rather than CLI.

This can be seen by doing the following:
1) `cd tests`
2) `uvicorn test_app.asgi:application`

## Checklist:

Please update this checklist as you complete each item:

-   [x] Tests have been included for all bug fixes or added functionality.
-   [x] The changelog has been updated with any significant changes, if necessary.
-   [x] GitHub Issues which may be closed by this PR have been linked.
