### PR TITLE
Add warning if poor performance is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
--   Nothing (yet)
+### Added
+
+-   Added warning if poor system/cache/database performance is detected.
 
 ## [3.1.0] - 2023-05-06
 

--- a/src/reactpy_django/websocket/consumer.py
+++ b/src/reactpy_django/websocket/consumer.py
@@ -77,7 +77,7 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
             carrier=ComponentWebsocket(self.close, self.disconnect, dotted_path),
         )
         now = timezone.now()
-        component_args: Sequence[Any] = tuple()
+        component_args: Sequence[Any] = ()
         component_kwargs: MutableMapping[str, Any] = {}
 
         # Verify the component has already been registered


### PR DESCRIPTION
## Description

Added warning on poor system/cache/database performance. This is detected when ReactPy-Django takes longer than one second to perform a `db_cleanup`

Ref: https://github.com/reactive-python/reactpy-django/discussions/128


## Checklist:

Please update this checklist as you complete each item:

-   [ ] Tests have been included for all bug fixes or added functionality.
-   [x] The changelog has been updated with any significant changes, if necessary.
-   [x] GitHub Issues which may be closed by this PR have been linked.
