### PR TITLE
v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Using the following categories, list your changes in this order:
 
 -   Changed implementation of `REACTPY_BACKHAUL_THREAD` to attempt increased performance compatibility.
 
+### Fixed
+
+-   Fix bug where `REACTPY_WEBSOCKET_URL` always generates a warning if unset.
+
 ## [3.3.1] - 2023-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,13 @@ Using the following categories, list your changes in this order:
 ### Added
 
 -   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance boost.
--   Built-in asyncio event loops are now patched via `nest_asyncio` to be re-enterant, resulting in an ~10% overall performance boost. This has no performance impact if you are running your webserver with `uvloop`.
+-   Built-in `asyncio` event loops are now patched via `nest_asyncio`, resulting in an ~10% overall performance boost on Windows. This has no performance impact if you are running your webserver with `uvloop`.
 
 ### Fixed
 
 -   Fix bug where `REACTPY_WEBSOCKET_URL` always generates a warning if unset.
--   Fixed bug where `assert f is self._write_fut` would be raised within Uvicorn on Windows when `REACTPY_BACKHAUL_THREAD = True`.
--   Fixed bug where rendering behavior would be jittery with Daphne on Windows when `REACTPY_BACKHAUL_THREAD = True`.
+-   Fixed bug where `assert f is self._write_fut` would be raised within `uvicorn` on Windows when `REACTPY_BACKHAUL_THREAD = True`.
+-   Fixed bug where rendering behavior would be jittery with `daphne` on Windows when `REACTPY_BACKHAUL_THREAD = True`.
 
 ## [3.3.1] - 2023-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Using the following categories, list your changes in this order:
 
 -   Nothing (yet)!
 
+## [3.3.2] - 2023-08-09
+
+### Changed
+
+-   Changed implementation of `REACTPY_BACKHAUL_THREAD` to attempt increased performance compatibility.
+
 ## [3.3.1] - 2023-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Using the following categories, list your changes in this order:
 
 ## [3.3.2] - 2023-08-09
 
+### Added
+
+-   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance boost.
+
 ### Changed
 
 -   Changed implementation of `REACTPY_BACKHAUL_THREAD` to attempt increased performance compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,18 +36,18 @@ Using the following categories, list your changes in this order:
 
 -   Nothing (yet)!
 
-## [3.3.2] - 2023-08-09
+## [3.3.2] - 2023-08-13
 
 ### Added
 
--   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance boost.
--   Built-in `asyncio` event loops are now patched via `nest_asyncio`, resulting in an ~10% overall performance boost on Windows. This has no performance impact if you are running your webserver with `uvloop`.
+-   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance improvement.
+-   Built-in `asyncio` event loops are now patched via `nest_asyncio`, resulting in an ~10% overall performance improvement. This has no performance impact if you are running your webserver with `uvloop`.
 
 ### Fixed
 
 -   Fix bug where `REACTPY_WEBSOCKET_URL` always generates a warning if unset.
--   Fixed bug where `assert f is self._write_fut` would be raised within `uvicorn` on Windows when `REACTPY_BACKHAUL_THREAD = True`.
--   Fixed bug where rendering behavior would be jittery with `daphne` on Windows when `REACTPY_BACKHAUL_THREAD = True`.
+-   Fixed bug on Windows where `assert f is self._write_fut` would be raised by `uvicorn` when `REACTPY_BACKHAUL_THREAD = True`.
+-   Fixed bug on Windows where rendering behavior would be jittery with `daphne` when `REACTPY_BACKHAUL_THREAD = True`.
 
 ## [3.3.1] - 2023-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,6 @@ Using the following categories, list your changes in this order:
 -   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance boost.
 -   Built-in asyncio event loops are now patched via `nest_asyncio` to be re-enterant, resulting in an ~10% overall performance boost. This has no performance impact if you are running your webserver with `uvloop`.
 
-### Changed
-
--   Changed implementation of `REACTPY_BACKHAUL_THREAD` to attempt increased performance compatibility.
-
 ### Fixed
 
 -   Fix bug where `REACTPY_WEBSOCKET_URL` always generates a warning if unset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Using the following categories, list your changes in this order:
 ### Added
 
 -   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance boost.
+-   Built-in asyncio event loops are now patched via `nest_asyncio` to be re-enterant, resulting in an ~10% overall performance boost. This has no performance impact if you are running your webserver with `uvloop`.
 
 ### Changed
 
@@ -49,6 +50,8 @@ Using the following categories, list your changes in this order:
 ### Fixed
 
 -   Fix bug where `REACTPY_WEBSOCKET_URL` always generates a warning if unset.
+-   Fixed bug where `assert f is self._write_fut` would be raised within Uvicorn on Windows when `REACTPY_BACKHAUL_THREAD = True`.
+-   Fixed bug where rendering behavior would be jittery with Daphne on Windows when `REACTPY_BACKHAUL_THREAD = True`.
 
 ## [3.3.1] - 2023-08-08
 

--- a/docs/python/settings.py
+++ b/docs/python/settings.py
@@ -27,6 +27,6 @@ REACTPY_DEFAULT_QUERY_POSTPROCESSOR = "reactpy_django.utils.django_query_postpro
 #   3. Your Django user model does not define a `backend` attribute
 REACTPY_AUTH_BACKEND = "django.contrib.auth.backends.ModelBackend"
 
-# Whether to enable rendering ReactPy via a dedicated backhaul thread
-# This allows the webserver to process traffic while during ReactPy rendering
+# Whether to enable rendering ReactPy via a dedicated backhaul thread.
+# This allows the webserver to process traffic while during ReactPy rendering.
 REACTPY_BACKHAUL_THREAD = False

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -3,5 +3,6 @@ django >=4.1.0
 reactpy >=1.0.0, <1.1.0
 aiofile >=3.0
 dill >=0.3.5
-orjson >=3.0.0
+orjson >=3.6.0
+nest_asyncio >=1.5.0
 typing_extensions

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -3,4 +3,5 @@ django >=4.1.0
 reactpy >=1.0.0, <1.1.0
 aiofile >=3.0
 dill >=0.3.5
+orjson >=3.0.0
 typing_extensions

--- a/src/reactpy_django/__init__.py
+++ b/src/reactpy_django/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
     "checks",
 ]
 # Built-in asyncio event loops can create `assert f is self._write_fut` exceptions
-# while we are using our backhaul thread, so we use this patch to fix this.
+# while we are using our backhaul thread with Uvicorn, so we use this patch to fix this.
 # This also resolves jittery rendering behaviors within Daphne. Can be demonstrated
 # using our "Renders Per Second" test page.
 with contextlib.suppress(ValueError):

--- a/src/reactpy_django/__init__.py
+++ b/src/reactpy_django/__init__.py
@@ -1,3 +1,7 @@
+import contextlib
+
+import nest_asyncio
+
 from reactpy_django import checks, components, decorators, hooks, types, utils
 from reactpy_django.websocket.paths import REACTPY_WEBSOCKET_PATH
 
@@ -11,3 +15,9 @@ __all__ = [
     "utils",
     "checks",
 ]
+# Built-in asyncio event loops can create `assert f is self._write_fut` exceptions
+# while we are using our backhaul thread, so we use this patch to fix this.
+# This also resolves jittery rendering behaviors within Daphne. Can be demonstrated
+# using our "Renders Per Second" test page.
+with contextlib.suppress(ValueError):
+    nest_asyncio.apply()

--- a/src/reactpy_django/checks.py
+++ b/src/reactpy_django/checks.py
@@ -97,7 +97,7 @@ def reactpy_warnings(app_configs, **kwargs):
         )
 
     # Check if REACTPY_WEBSOCKET_URL doesn't end with a slash
-    REACTPY_WEBSOCKET_URL = getattr(settings, "REACTPY_WEBSOCKET_URL", "")
+    REACTPY_WEBSOCKET_URL = getattr(settings, "REACTPY_WEBSOCKET_URL", "reactpy/")
     if isinstance(REACTPY_WEBSOCKET_URL, str):
         if not REACTPY_WEBSOCKET_URL or not REACTPY_WEBSOCKET_URL.endswith("/"):
             warnings.append(

--- a/src/reactpy_django/websocket/consumer.py
+++ b/src/reactpy_django/websocket/consumer.py
@@ -10,6 +10,7 @@ from threading import Thread
 from typing import Any, MutableMapping, Sequence
 
 import dill as pickle
+import orjson
 from channels.auth import login
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
@@ -106,6 +107,14 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
             ).result()
 
         return await super().dispatch(message)
+
+    @classmethod
+    async def decode_json(cls, text_data):
+        return orjson.loads(text_data)
+
+    @classmethod
+    async def encode_json(cls, content):
+        return orjson.dumps(content).decode()
 
     async def run_dispatcher(self):
         """Runs the main loop that performs component rendering tasks."""

--- a/src/reactpy_django/websocket/consumer.py
+++ b/src/reactpy_django/websocket/consumer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from concurrent.futures import Future
 from datetime import timedelta
 from threading import Thread
 from typing import Any, MutableMapping, Sequence
@@ -41,7 +42,7 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
 
     async def connect(self) -> None:
         """The browser has connected."""
-        from reactpy_django.config import REACTPY_AUTH_BACKEND
+        from reactpy_django.config import REACTPY_AUTH_BACKEND, REACTPY_BACKHAUL_THREAD
 
         await super().connect()
 
@@ -77,36 +78,33 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
             )
 
         # Start the component dispatcher
-        self.recv_queue: asyncio.Queue = asyncio.Queue()
-        self.dispatcher = asyncio.create_task(self.run_dispatcher())
-
-    async def disconnect(self, code: int) -> None:
-        """The browser has disconnected."""
-        self.dispatcher.cancel()
-        await self.dispatcher
-        await super().disconnect(code)
-
-    async def receive_json(self, content: Any, **_) -> None:
-        """Receive a message from the browser. Typically, messages are event signals."""
-        await self.recv_queue.put(content)
-
-    async def dispatch(self, message):
-        """Override the Django Channels dispatch method to allow running the ASGI
-        dispatcher in a thread."""
-        from reactpy_django.config import REACTPY_BACKHAUL_THREAD
-
-        if REACTPY_BACKHAUL_THREAD:
+        self.dispatcher: Future | asyncio.Task
+        self.threaded = REACTPY_BACKHAUL_THREAD
+        if self.threaded:
             if not backhaul_thread.is_alive():
                 await asyncio.to_thread(
                     _logger.debug, "Starting ReactPy backhaul thread."
                 )
                 backhaul_thread.start()
+            self.dispatcher = asyncio.run_coroutine_threadsafe(
+                self.run_dispatcher(), backhaul_loop
+            )
+        else:
+            self.dispatcher = asyncio.create_task(self.run_dispatcher())
 
-            return asyncio.run_coroutine_threadsafe(
-                super().dispatch(message), backhaul_loop
-            ).result()
+    async def disconnect(self, code: int) -> None:
+        """The browser has disconnected."""
+        self.dispatcher.cancel()
+        await super().disconnect(code)
 
-        return await super().dispatch(message)
+    async def receive_json(self, content: Any, **_) -> None:
+        """Receive a message from the browser. Typically, messages are event signals."""
+        if self.threaded:
+            asyncio.run_coroutine_threadsafe(
+                self.recv_queue.put(content), backhaul_loop
+            )
+        else:
+            await self.recv_queue.put(content)
 
     @classmethod
     async def decode_json(cls, text_data):
@@ -128,6 +126,7 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
         dotted_path = scope["url_route"]["kwargs"]["dotted_path"]
         uuid = scope["url_route"]["kwargs"]["uuid"]
         search = scope["query_string"].decode()
+        self.recv_queue: asyncio.Queue = asyncio.Queue()
         connection = Connection(  # For `use_connection`
             scope=scope,
             location=Location(

--- a/tests/test_app/templates/events_renders_per_second.html
+++ b/tests/test_app/templates/events_renders_per_second.html
@@ -17,6 +17,7 @@
         <p>Total Active Components: <b id="total-active"></b></p>
         <p>Time To Load: <b id="time-to-load" data-num=0></b></p>
         <p>Event Renders Per Second: <b id="total-erps"></b></p>
+        <p>Event Renders Per Second (Estimated Minimum): <b id="min-rps"></b></p>
         <p>Average Round-Trip Time: <b id="avg-event-rt"></b></p>
     </b>
 
@@ -49,6 +50,16 @@
                     totalEPS += parseFloat(elements[i].getAttribute("data-erps"));
                 }
                 document.getElementById("total-erps").textContent = totalEPS;
+
+                // Calculate Min RPS
+                let minRPS = 0;
+                for (let i = 0; i < elements.length; i++) {
+                    let rpsValue = parseFloat(elements[i].getAttribute("data-erps"));
+                    if (rpsValue < minRPS || minRPS == 0) {
+                        minRPS = rpsValue;
+                    }
+                }
+                document.getElementById("min-rps").textContent = minRPS * elements.length;
 
                 // Calculate Average Event Round-Trip Time
                 document.getElementById("avg-event-rt").textContent = ((1000 / totalEPS) * elements.length).toFixed(4) + " ms";

--- a/tests/test_app/templates/mixed_time_to_load.html
+++ b/tests/test_app/templates/mixed_time_to_load.html
@@ -17,6 +17,7 @@
         <p>Total Active Components: <b id="total-active"></b></p>
         <p>Time To Load: <b id="time-to-load" data-num=0></b></p>
         <p>Total Renders Per Second: <b id="total-rps"></b></p>
+        <p>Total Renders Per Second (Estimated Minimum): <b id="min-rps"></b></p>
     </b>
 
     <script>
@@ -42,6 +43,16 @@
                     totalRPS += rpsValue;
                 }
                 document.getElementById("total-rps").textContent = totalRPS;
+
+                // Calculate Min RPS
+                let minRPS = 0;
+                for (let i = 0; i < elements.length; i++) {
+                    let rpsValue = parseFloat(elements[i].getAttribute("data-rps"));
+                    if (rpsValue < minRPS || minRPS == 0) {
+                        minRPS = rpsValue;
+                    }
+                }
+                document.getElementById("min-rps").textContent = minRPS * elements.length;
 
                 await new Promise(resolve => setTimeout(resolve, 50));
             }

--- a/tests/test_app/templates/renders_per_second.html
+++ b/tests/test_app/templates/renders_per_second.html
@@ -17,6 +17,7 @@
         <p>Total Active Components: <b id="total-active"></b></p>
         <p>Time To Load: <b id="time-to-load" data-num=0></b></p>
         <p>Total Renders Per Second: <b id="total-rps"></b></p>
+        <p>Total Renders Per Second (Estimated Minimum): <b id="min-rps"></b></p>
     </b>
 
     <script>
@@ -42,6 +43,16 @@
                     totalRPS += rpsValue;
                 }
                 document.getElementById("total-rps").textContent = totalRPS;
+
+                // Calculate Min RPS
+                let minRPS = 0;
+                for (let i = 0; i < elements.length; i++) {
+                    let rpsValue = parseFloat(elements[i].getAttribute("data-rps"));
+                    if (rpsValue < minRPS || minRPS == 0) {
+                        minRPS = rpsValue;
+                    }
+                }
+                document.getElementById("min-rps").textContent = minRPS * elements.length;
 
                 await new Promise(resolve => setTimeout(resolve, 50));
             }


### PR DESCRIPTION
*By submitting this pull request you agree that all contributions to this project are made under the MIT license.*

## Description

### Added

-   ReactPy Websocket will now decode messages via `orjson` resulting in an ~6% overall performance boost.
-   Built-in `asyncio` event loops are now patched via `nest_asyncio`, resulting in an ~10% overall performance boost on Windows. This has no performance impact if you are running your webserver with `uvloop`.

### Fixed

-   Fix bug where `REACTPY_WEBSOCKET_URL` always generates a warning if unset.
-   Fixed bug where `assert f is self._write_fut` would be raised within `uvicorn` on Windows when `REACTPY_BACKHAUL_THREAD = True`.
-   Fixed bug where rendering behavior would be jittery with `daphne` on Windows when `REACTPY_BACKHAUL_THREAD = True`.
