### PR TITLE
always pass-through args/kwargs to database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ Using the following categories, list your changes in this order:
 
 ### Changed
 
--   Bumped the minimum ReactPy version to 1.0.2
--   Prettier websocket URLs for components that do not have sessions
+-   Bumped the minimum ReactPy version to `1.0.2`.
+-   Prettier websocket URLs for components that do not have sessions.
+-   Template tag will now only validate `args`/`kwargs` if `settings.py:DEBUG` is enabled.
 
 ## [3.4.0] - 2023-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
--   Nothing (yet)!
+### Changed
+
+-   Bumped the minimum ReactPy version to 1.0.2
+-   Prettier websocket URLs for components that do not have sessions
 
 ## [3.4.0] - 2023-08-18
 

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -1,6 +1,6 @@
 channels >=4.0.0
 django >=4.1.0
-reactpy >=1.0.0, <1.1.0
+reactpy >=1.0.2, <1.1.0
 aiofile >=3.0
 dill >=0.3.5
 orjson >=3.6.0

--- a/src/reactpy_django/utils.py
+++ b/src/reactpy_django/utils.py
@@ -302,7 +302,7 @@ def func_has_args(func) -> bool:
     return bool(inspect.signature(func).parameters)
 
 
-def check_component_args(func, *args, **kwargs):
+def validate_component_args(func, *args, **kwargs):
     """
     Validate whether a set of args/kwargs would work on the given function.
 

--- a/src/reactpy_django/utils.py
+++ b/src/reactpy_django/utils.py
@@ -297,11 +297,6 @@ def django_query_postprocessor(
     return data
 
 
-def func_has_args(func) -> bool:
-    """Checks if a function has any args or kwargs."""
-    return bool(inspect.signature(func).parameters)
-
-
 def validate_component_args(func, *args, **kwargs):
     """
     Validate whether a set of args/kwargs would work on the given function.

--- a/src/reactpy_django/websocket/consumer.py
+++ b/src/reactpy_django/websocket/consumer.py
@@ -124,7 +124,7 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
 
         scope = self.scope
         dotted_path = scope["url_route"]["kwargs"]["dotted_path"]
-        uuid = scope["url_route"]["kwargs"]["uuid"]
+        uuid = scope["url_route"]["kwargs"].get("uuid")
         search = scope["query_string"].decode()
         self.recv_queue: asyncio.Queue = asyncio.Queue()
         connection = Connection(  # For `use_connection`

--- a/src/reactpy_django/websocket/consumer.py
+++ b/src/reactpy_django/websocket/consumer.py
@@ -22,7 +22,7 @@ from reactpy.core.layout import Layout
 from reactpy.core.serve import serve_layout
 
 from reactpy_django.types import ComponentParamData, ComponentWebsocket
-from reactpy_django.utils import db_cleanup, func_has_args
+from reactpy_django.utils import db_cleanup
 
 _logger = logging.getLogger(__name__)
 backhaul_loop = asyncio.new_event_loop()
@@ -151,7 +151,7 @@ class ReactpyAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
 
         # Fetch the component's args/kwargs from the database, if needed
         try:
-            if func_has_args(component_constructor):
+            if uuid:
                 # Always clean up expired entries first
                 await database_sync_to_async(db_cleanup, thread_sensitive=False)()
 

--- a/src/reactpy_django/websocket/paths.py
+++ b/src/reactpy_django/websocket/paths.py
@@ -1,3 +1,4 @@
+from channels.routing import URLRouter  # noqa: E402
 from django.urls import path
 
 from reactpy_django.config import REACTPY_URL_PREFIX
@@ -5,8 +6,13 @@ from reactpy_django.config import REACTPY_URL_PREFIX
 from .consumer import ReactpyAsyncWebsocketConsumer
 
 REACTPY_WEBSOCKET_ROUTE = path(
-    f"{REACTPY_URL_PREFIX}/<dotted_path>/<uuid>/",
-    ReactpyAsyncWebsocketConsumer.as_asgi(),
+    f"{REACTPY_URL_PREFIX}/<dotted_path>/",
+    URLRouter(
+        [
+            path("<uuid>/", ReactpyAsyncWebsocketConsumer.as_asgi()),
+            path("", ReactpyAsyncWebsocketConsumer.as_asgi()),
+        ]
+    ),
 )
 """A URL path for :class:`ReactpyAsyncWebsocketConsumer`.
 


### PR DESCRIPTION
*By submitting this pull request you agree that all contributions to this project are made under the MIT license.*

## Description

-   Bumped the minimum ReactPy version to `1.0.2`.
-   Prettier websocket URLs for components that do not have sessions.
-   Template tag will now only validate `args`/`kwargs` if `settings.py:DEBUG` is enabled.

## Checklist:

Please update this checklist as you complete each item:

-   [x] Tests have been included for all bug fixes or added functionality.
-   [x] The changelog has been updated with any significant changes, if necessary.
-   [x] GitHub Issues which may be closed by this PR have been linked.
