### PR TITLE
Add git user to mike deployment

### DIFF
--- a/.github/workflows/publish-develop-docs.yml
+++ b/.github/workflows/publish-develop-docs.yml
@@ -15,4 +15,7 @@ jobs:
                   python-version: 3.x
             - run: pip install -r requirements/build-docs.txt
             - name: Publish Develop Docs
-              run: mike deploy --push develop
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com 
+                  mike deploy --push develop

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -16,4 +16,7 @@ jobs:
                   python-version: 3.x
             - run: pip install -r requirements/build-docs.txt
             - name: Publish ${{ github.event.release.name }} Docs
-              run: mike deploy --push --update-aliases ${{ github.event.release.name }} latest
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com 
+                  mike deploy --push --update-aliases ${{ github.event.release.name }} latest


### PR DESCRIPTION
*By submitting this pull request you agree that all contributions to this project are made under the MIT license.*

## Description

Mike requires a `git.user` otherwise it will fail to deploy.

ref: https://github.com/jimporter/mike/issues/49
