### PR TITLE
Use `NodeJS-bin` instead of the user's `node` install

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [rmorshea]
+github: [archmonger]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -12,9 +12,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "20.x"
             - name: Set up Python
               uses: actions/setup-python@v1
               with:

--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -19,10 +19,6 @@ jobs:
               uses: actions/setup-python@v1
               with:
                   python-version: "3.x"
-            - name: Install NPM
-              run: |
-                  npm install -g npm@latest
-                  npm --version
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -18,9 +18,6 @@ jobs:
                 python-version: ["3.9", "3.10", "3.11"]
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "20.x"
             - name: Use Python ${{ matrix.python-version }}
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -29,6 +29,4 @@ jobs:
               run: pip install -r requirements/test-run.txt
             - name: Run Tests
               run: |
-                  npm install -g npm@latest
-                  npm --version
                   nox -s test

--- a/docs/src/about/code.md
+++ b/docs/src/about/code.md
@@ -20,7 +20,6 @@ If you plan to make code changes to this repository, you will need to install th
 
 -   [Python 3.9+](https://www.python.org/downloads/)
 -   [Git](https://git-scm.com/downloads)
--   [NPM](https://docs.npmjs.com/try-the-latest-stable-version-of-npm) for installing and managing Javascript
 
 Once done, you should clone this repository:
 

--- a/docs/src/about/code.md
+++ b/docs/src/about/code.md
@@ -29,33 +29,20 @@ git clone https://github.com/reactive-python/reactpy-django.git
 cd reactpy-django
 ```
 
-Then, by running the command below you can:
-
--   Install an editable version of the Python code
--   Download, build, and install Javascript dependencies
+Then, by running the command below you can install the dependencies needed to run the ReactPy Django development environment.
 
 ```bash linenums="0"
-pip install -e . -r requirements.txt --verbose --upgrade
+pip install -r requirements.txt --upgrade --verbose
 ```
 
 !!! warning "Pitfall"
 
-    Some of our development dependencies require a C++ compiler, which is not installed by default on Windows.
+    Some of our development dependencies require a C++ compiler, which is not installed by default on Windows. If you receive errors related to this during installation, follow the instructions in your console errors.
 
-    If you receive errors related to this during installation, follow the instructions in your console errors.
+    Additionally, be aware that ReactPy Django's JavaScript bundle is built within the following scenarios:
 
-Finally, to verify that everything is working properly, you can manually run the test web server.
-
-```bash linenums="0"
-cd tests
-python manage.py runserver
-```
-
-Navigate to [`http://127.0.0.1:8000`](http://127.0.0.1:8000) to see if the tests are rendering correctly.
-
-## Creating a pull request
-
-{% include-markdown "../../includes/pr.md" %}
+    1. When `pip install` is run on the `reactpy-django` package.
+    2. Every time `python manage.py ...` or `nox ...` is run
 
 ## Running the full test suite
 
@@ -92,3 +79,7 @@ If you want to manually run the Django test application, you can use the followi
 cd tests
 python manage.py runserver
 ```
+
+## Creating a pull request
+
+{% include-markdown "../../includes/pr.md" %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "nodejs-bin==18.4.0a4"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]

--- a/requirements/test-env.txt
+++ b/requirements/test-env.txt
@@ -3,3 +3,4 @@ twisted
 channels[daphne]>=4.0.0
 tblib
 whitenoise
+nodejs-bin==18.4.0a4

--- a/tests/test_app/__init__.py
+++ b/tests/test_app/__init__.py
@@ -4,5 +4,5 @@ from nodejs import npm
 
 # Make sure the JS is always re-built before running the tests
 js_dir = Path(__file__).parent.parent.parent / "src" / "js"
-npm.call(["install"], cwd=str(js_dir))
-npm.call(["run", "build"], cwd=str(js_dir))
+assert npm.call(["install"], cwd=str(js_dir)) == 0
+assert npm.call(["run", "build"], cwd=str(js_dir)) == 0

--- a/tests/test_app/__init__.py
+++ b/tests/test_app/__init__.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from nodejs import npm
+
+# Make sure the JS is always re-built before running the tests
+js_dir = Path(__file__).parent.parent.parent / "src" / "js"
+npm.call(["install"], cwd=str(js_dir))
+npm.call(["run", "build"], cwd=str(js_dir))


### PR DESCRIPTION
## Description

Our test suite currently relies on the user manually installing `NodeJS` in order for `npm` commands to be run.

This is an error prone process with way to control what `npm` version the end-user has. This method also can also fail due to missing `PATH` variables.

This PR uses premade binaries for `npm` instead of the user's local `npm` installation.

## Checklist:

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request you agree that all contributions comply with this project's open source license(s).</sub>
