### PR TITLE
Support rendering Django forms within ReactPy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Description
 
-A summary of the changes.
+<!-- A summary of the changes. -->
 
 ## Checklist:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,9 +103,14 @@ Using the following categories, list your changes in this order:
 -   Prettier WebSocket URLs for components that do not have sessions.
 -   Template tag will now only validate `args`/`kwargs` if `settings.py:DEBUG` is enabled.
 -   Bumped the minimum `@reactpy/client` version to `0.3.1`
--   Bumped the minimum Django version to `4.2`.
 -   Use TypeScript instead of JavaScript for this repository.
-    -   Note: ReactPy-Django will continue bumping minimum Django requirements to versions that increase async support. This "latest-only" trend will continue until Django has all async features that ReactPy benefits from. After this point, ReactPy-Django will begin supporting all maintained Django versions.
+-   Bumped the minimum Django version to `4.2`.
+
+???+ note "Django 4.2+ is required"
+
+    ReactPy-Django will continue bumping minimum Django requirements to versions that increase async support.
+
+    This "latest-only" trend will continue until Django has all async features that ReactPy benefits from. After this point, ReactPy-Django will begin supporting all maintained Django versions.
 
 ### Removed
 

--- a/src/reactpy_django/components.py
+++ b/src/reactpy_django/components.py
@@ -304,6 +304,8 @@ def _django_form(
                     *bottom_children or "",
                 )
             )
+            # TODO: When ReactPy starts serializing the `name` field of input elements,
+            # we will need to make sure all inputs have a name attribute here
             set_render_needed(False)
 
     @event(prevent_default=True)

--- a/src/reactpy_django/decorators.py
+++ b/src/reactpy_django/decorators.py
@@ -32,7 +32,7 @@ def auth_required(
 
     warn(
         "auth_required is deprecated and will be removed in the next major version. "
-        "An equivalent to this decorator's default is @user_passes_test('is_active').",
+        "An equivalent to this decorator's default is @user_passes_test(lambda user: user.is_active).",
         DeprecationWarning,
     )
 

--- a/src/reactpy_django/utils.py
+++ b/src/reactpy_django/utils.py
@@ -80,7 +80,7 @@ async def render_form(
     template_name: str | None,
     context: dict | None,
     request: HttpRequest | None = None,
-):
+) -> str:
     """Renders a Django form asynchronously."""
     return await database_sync_to_async(form.renderer.render)(
         template_name=template_name, context=context or {}, request=request

--- a/src/reactpy_django/utils.py
+++ b/src/reactpy_django/utils.py
@@ -24,7 +24,7 @@ from django.utils import timezone
 from django.utils.encoding import smart_str
 from django.views import View
 from reactpy.core.layout import Layout
-from reactpy.types import ComponentConstructor, VdomDict
+from reactpy.types import ComponentConstructor
 
 from reactpy_django.exceptions import (
     ComponentDoesNotExistError,

--- a/src/reactpy_django/utils.py
+++ b/src/reactpy_django/utils.py
@@ -17,6 +17,7 @@ from channels.db import database_sync_to_async
 from django.db.models import ManyToManyField, ManyToOneRel, prefetch_related_objects
 from django.db.models.base import Model
 from django.db.models.query import QuerySet
+from django.forms import Form
 from django.http import HttpRequest, HttpResponse
 from django.template import engines
 from django.utils import timezone
@@ -72,6 +73,18 @@ async def render_view(
         response = await database_sync_to_async(response.render)()
 
     return response
+
+
+async def render_form(
+    form: Form,
+    template_name: str | None,
+    context: dict | None,
+    request: HttpRequest | None = None,
+):
+    """Renders a Django form asynchronously."""
+    return await database_sync_to_async(form.renderer.render)(
+        template_name=template_name, context=context or {}, request=request
+    )
 
 
 def register_component(component: ComponentConstructor | str):

--- a/tests/test_app/components.py
+++ b/tests/test_app/components.py
@@ -8,7 +8,7 @@ from channels.db import database_sync_to_async
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.shortcuts import render
-from reactpy import component, hooks, html, web
+from reactpy import component, event, hooks, html, web
 from reactpy_django.components import view_to_component, view_to_iframe
 from reactpy_django.types import QueryOptions
 
@@ -808,4 +808,31 @@ def use_user_data_with_default():
                 {"on_key_press": on_submit, "placeholder": "Type here to add data"}
             )
         ),
+    )
+
+
+@component
+def example():
+    @event(prevent_default=True)
+    def on_submit(event):
+        ...
+
+    return html.form(
+        {"on_submit": on_submit},
+        html.input({"type": "text"}),
+        html.div(
+            html.input({"type": "text"}),
+        ),
+        html.input({"type": "text", "disabled": True}),
+        html.textarea("Hello World"),
+        html.select(
+            html.option("Hello"),
+            html.option("World"),
+        ),
+        html.input({"type": "checkbox"}),
+        html.fieldset(
+            html.input({"type": "radio", "name": "radio"}),
+            html.input({"type": "radio", "name": "radio"}),
+        ),
+        html.button({"type": "submit"}, "Submit"),
     )


### PR DESCRIPTION
## Description

Adds a `django_form` component that can automagically ingest a Django form and spit out a component.

## Checklist:

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request you agree that all contributions comply with this project's open source license(s).</sub>
