### PR TITLE
Fix Python and docs tests

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -23,6 +23,8 @@ jobs:
             - name: Check docs links
               uses: umbrelladocs/action-linkspector@v1
               with:
+                  github_token: ${{ secrets.github_token }}
+                  reporter: github-pr-review
                   fail_on_error: true
             - name: Check docs build
               run: |

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -20,12 +20,13 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                   python-version: 3.x
+            - name: Check docs links
+              uses: umbrelladocs/action-linkspector@v1
+              with:
+                  fail_on_error: true
             - name: Check docs build
               run: |
                   pip install -r requirements/build-docs.txt
-                  linkcheckMarkdown docs/ -v -r
-                  linkcheckMarkdown README.md -v -r
-                  linkcheckMarkdown CHANGELOG.md -v -r
                   cd docs
                   mkdocs build --strict
             - name: Check docs examples

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+docs/site
 
 # mypy
 .mypy_cache/

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+    - ./docs
+files:
+    - README.md
+    - CHANGELOG.md
+useGitIgnore: true
+modifiedFilesOnly: false

--- a/requirements/build-docs.txt
+++ b/requirements/build-docs.txt
@@ -2,7 +2,6 @@ mkdocs
 mkdocs-git-revision-date-localized-plugin
 mkdocs-material==9.4.0
 mkdocs-include-markdown-plugin
-linkcheckmd
 mkdocs-spellcheck[all]
 mkdocs-git-authors-plugin
 mkdocs-minify-plugin

--- a/src/reactpy_django/clean.py
+++ b/src/reactpy_django/clean.py
@@ -87,7 +87,7 @@ def clean_user_data(verbosity: int = 1):
     start_time = timezone.now()
     user_model = get_user_model()
     all_users = user_model.objects.all()
-    all_user_pks = all_users.values_list(user_model._meta.pk.name, flat=True)  # type: ignore
+    all_user_pks = all_users.values_list(user_model._meta.pk.name, flat=True)
 
     # Django doesn't support using QuerySets as an argument with cross-database relations.
     if user_model.objects.db != UserDataModel.objects.db:


### PR DESCRIPTION
## Description

- Fix python tests failures caused by upgraded mypy stubs
- Switch `linkcheckmd` to it's replacement `linkspector`
   - `linkcheckmd` needs to be removed because `ReadTheDocs` has started to blacklist GitHub workflow IPs, and `linkcheckmd` has no configuration for excluding URL patterns. 
   - As a note, it looks like the the latest version of the `linkspector` workflow has broken directory scanning. Am going to move forward with this PR anyways in the hopes that it gets fixed soon.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
