### PR TITLE
Remove HATCH_INDEX_REPO from CI

### DIFF
--- a/.github/workflows/publish-py.yml
+++ b/.github/workflows/publish-py.yml
@@ -27,5 +27,4 @@ jobs:
               env:
                   HATCH_INDEX_USER: ${{ secrets.PYPI_USERNAME }}
                   HATCH_INDEX_AUTH: ${{ secrets.PYPI_PASSWORD }}
-                  HATCH_INDEX_REPO: reactpy-django
               run: hatch publish --yes


### PR DESCRIPTION
## Description

Looks I misused the `HATCH_INDEX_REPO` environment variable. I don't believe it's mandatory so will be testing publishing with it removed.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
