### PR TITLE
Resolve `reactpy_resolved_web_modules_path` within component tag body

### DIFF
--- a/src/reactpy_django/templatetags/reactpy.py
+++ b/src/reactpy_django/templatetags/reactpy.py
@@ -29,10 +29,6 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
     from reactpy.core.types import ComponentConstructor, ComponentType, VdomDict
 
-try:
-    RESOLVED_WEB_MODULES_PATH = reverse("reactpy:web_modules", args=["/"]).strip("/")
-except NoReverseMatch:
-    RESOLVED_WEB_MODULES_PATH = ""
 register = template.Library()
 _logger = getLogger(__name__)
 
@@ -161,6 +157,10 @@ def component(
             _logger.error(msg)
             return failure_context(dotted_path, ComponentCarrierError(msg))
         _offline_html = prerender_component(offline_component, [], {}, uuid, request)
+    try:
+        resolved_web_modules_path = reverse("reactpy:web_modules", args=["/"]).strip("/")
+    except NoReverseMatch:
+        resolved_web_modules_path = ""
 
     # Return the template rendering context
     return {
@@ -169,7 +169,7 @@ def component(
         "reactpy_host": host or perceived_host,
         "reactpy_url_prefix": reactpy_config.REACTPY_URL_PREFIX,
         "reactpy_component_path": f"{dotted_path}/{uuid}/{int(has_args)}/",
-        "reactpy_resolved_web_modules_path": RESOLVED_WEB_MODULES_PATH,
+        "reactpy_resolved_web_modules_path": resolved_web_modules_path,
         "reactpy_reconnect_interval": reactpy_config.REACTPY_RECONNECT_INTERVAL,
         "reactpy_reconnect_max_interval": reactpy_config.REACTPY_RECONNECT_MAX_INTERVAL,
         "reactpy_reconnect_backoff_multiplier": reactpy_config.REACTPY_RECONNECT_BACKOFF_MULTIPLIER,


### PR DESCRIPTION

## Description

Calling `reverse("reactpy:web_modules", args=["/"])` in the main script will always raise a `NoReverseMatch` exception because the app is not loaded yet.

This also causes a bug that affects the unfold project, however that is not the primary cause for this bug.

I moved this function to the body of the component function.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
