### PR TITLE
v6.0.0b1

### DIFF
--- a/.github/workflows/publish-latest-docs.yml
+++ b/.github/workflows/publish-latest-docs.yml
@@ -2,7 +2,7 @@ name: Publish Latest Docs
 
 on:
     release:
-        types: [published]
+        types: [released]
 
 jobs:
     publish-latest-docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ Don't forget to remove deprecated code on each major release!
 - To improve performance, `preact` is now used as the default client-side library instead of `react`.
 - ReactPy v2 compatibility! This release aligns `reactpy-django` with ReactPy v2's API.
     - Refactored `DjangoResolver` to extend `ReactPyResolver` instead of `StarletteResolver`.
-    - Replaced `reactpy_router.resolvers.StarletteResolver` with `ReactPyResolver` for Django URL routing.
     - Replaced `web.module_from_file`/`web.export` with `reactjs.component_from_file`.
     - Replaced `reactpy.backend.types` and `reactpy.core.types` imports with `reactpy.types`.
     - Renamed `Location.pathname` to `Location.path` and `Location.search` to `Location.query_string`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Don't forget to remove deprecated code on each major release!
 
 ### Added
 
-- Automatic serve ReactPy wheel from Django's static directory when using PyScript.
+- Automatically serve ReactPy wheel from Django's static directory when using PyScript.
 
 ### Changed
 
@@ -34,10 +34,9 @@ Don't forget to remove deprecated code on each major release!
     - The `group_name` argument has been renamed to `group`.
     - The `group_add` and `group_discard` arguments have been removed for simplicity.
 - To improve performance, `preact` is now used as the default client-side library instead of `react`.
-- Refactored `DjangoResolver` to extend `ReactPyResolver` instead of `StarletteResolver`.
-- Replaced `reactpy_router.resolvers.StarletteResolver` with `ReactPyResolver` for Django URL routing.
-- Moved `{% load reactpy %}` to after `<!DOCTYPE html>` in HTML templates for standards compliance.
 - ReactPy v2 compatibility! This release aligns `reactpy-django` with ReactPy v2's API.
+    - Refactored `DjangoResolver` to extend `ReactPyResolver` instead of `StarletteResolver`.
+    - Replaced `reactpy_router.resolvers.StarletteResolver` with `ReactPyResolver` for Django URL routing.
     - Replaced `web.module_from_file`/`web.export` with `reactjs.component_from_file`.
     - Replaced `reactpy.backend.types` and `reactpy.core.types` imports with `reactpy.types`.
     - Renamed `Location.pathname` to `Location.path` and `Location.search` to `Location.query_string`.
@@ -46,8 +45,8 @@ Don't forget to remove deprecated code on each major release!
 
 - Removed `reactpy_django.components.pyscript_component`. Use `reactpy.executors.pyscript.pyscript_component` instead.
 - Removed the entire `reactpy_django/pyscript/` package (component template, layout handler, and utilities) in favor of ReactPy core's PyScript executor.
-- Removed `reactpy_django/html.py` (`pyscript` VDOM constructor). Use `html.py_script` instead.
-- Removed `nest_asyncio` dependency and its initialization on startup.
+- Removed `reactpy_django.html.pyscript`. Use `reactpy.html.py_script` instead.
+- Removed `nest_asyncio` dependency.
 
 ### Fixed
 

--- a/src/reactpy_django/__init__.py
+++ b/src/reactpy_django/__init__.py
@@ -8,7 +8,7 @@ from reactpy_django import (
 )
 from reactpy_django.websocket.paths import REACTPY_WEBSOCKET_ROUTE
 
-__version__ = "5.2.1"
+__version__ = "6.0.0b1"
 __all__ = [
     "REACTPY_WEBSOCKET_ROUTE",
     "components",


### PR DESCRIPTION
## Description

Beta version release

### Added

- Automatically serve ReactPy wheel from Django's static directory when using PyScript.

### Changed

- Updated dependencies: `reactpy>=2.0.0, <3.0.0` and `reactpy-router>=3.0.0, <4.0.0`.
- Updated Python support to 3.11–3.14.
- Replaced PyScript `<py-script>` tags with standard `<script type="py">` tags.
- Updated the interface for `reactpy.hooks.use_channel_layer` to be more intuitive.
    - Arguments now must be provided as keyworded arguments.
    - The `name` argument has been renamed to `channel`.
    - The `group_name` argument has been renamed to `group`.
    - The `group_add` and `group_discard` arguments have been removed for simplicity.
- To improve performance, `preact` is now used as the default client-side library instead of `react`.
- ReactPy v2 compatibility! This release aligns `reactpy-django` with ReactPy v2's API.
    - Refactored `DjangoResolver` to extend `ReactPyResolver` instead of `StarletteResolver`.
    - Replaced `web.module_from_file`/`web.export` with `reactjs.component_from_file`.
    - Replaced `reactpy.backend.types` and `reactpy.core.types` imports with `reactpy.types`.
    - Renamed `Location.pathname` to `Location.path` and `Location.search` to `Location.query_string`.

### Removed

- Removed `reactpy_django.components.pyscript_component`. Use `reactpy.executors.pyscript.pyscript_component` instead.
- Removed the entire `reactpy_django/pyscript/` package (component template, layout handler, and utilities) in favor of ReactPy core's PyScript executor.
- Removed `reactpy_django.html.pyscript`. Use `reactpy.html.py_script` instead.
- Removed `nest_asyncio` dependency.

### Fixed

- Resolved bug where `django_form` events would sometimes not occur.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
